### PR TITLE
remove 2-3 lines limitation on coding conventions/style section

### DIFF
--- a/readme-template.md
+++ b/readme-template.md
@@ -38,7 +38,7 @@ Describe your Git/GitHub workflow. Essentially, we want to understand how your t
  * Don't forget to **briefly justify why** you chose this workflow or particular aspects of it!
 
  ## Coding Standards and Guidelines
- Keep this section brief, a maximum of 2-3 lines. You would want to read through this [article](https://www.geeksforgeeks.org/coding-standards-and-guidelines/) to get more context about what this section is for before attempting to answer.
+ Keep this section brief, 2-3 minute read. You would want to read through this [article](https://www.geeksforgeeks.org/coding-standards-and-guidelines/) to get more context about what this section is for before attempting to answer.
   * These are 2 optional resources that you might want to go through: [article with High level explanation](https://blog.codacy.com/coding-standards-what-are-they-and-why-do-you-need-them/) and [this article with Detailed Explanation](https://google.github.io/styleguide/)
 ​
  ## Licenses 


### PR DESCRIPTION
A lot of teams effectively skipped making decisions in this section because they were wary of this 2-3 line limit. I believe that 2-3 lines isn't enough space to define meaningful coding standards/guidelines. I felt that teams that ignored this limitation answered this section much better, defining naming conventions, which linter they'll use, indentation, docstrings, etc.